### PR TITLE
twig formatter

### DIFF
--- a/Formatter/TwigFilterFormatterInterface.php
+++ b/Formatter/TwigFilterFormatterInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace whatwedo\CoreBundle\Formatter;
+
+use Twig\Extension\ExtensionInterface;
+
+interface TwigFilterFormatterInterface extends ExtensionInterface
+{
+}

--- a/Formatter/TwigFilterTrait.php
+++ b/Formatter/TwigFilterTrait.php
@@ -7,6 +7,9 @@ use Twig\TwigFilter;
 
 trait TwigFilterTrait
 {
+    abstract public function getHtml($data);
+    abstract public function processOptions(?array $options);
+
     protected function getFilterName(): string
     {
         $arr = explode('\\', self::class);
@@ -23,10 +26,6 @@ trait TwigFilterTrait
     }
 
     private function applyFormatter($data, array $options = []) {
-        if (!$this instanceof FormatterInterface) {
-            throw new \Exception('TwigFilterTrait can only used on FormatterInterface classes');
-        }
-
         $this->processOptions($options);
         return new Markup($this->getHtml($data), 'UTF-8');
     }

--- a/Formatter/TwigFilterTrait.php
+++ b/Formatter/TwigFilterTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace whatwedo\CoreBundle\Formatter;
+
+use Twig\Markup;
+use Twig\TwigFilter;
+
+trait TwigFilterTrait
+{
+    protected function getFilterName(): string
+    {
+        $arr = explode('\\', self::class);
+        $filterName = array_pop($arr);
+
+        return $this->camel_to_snake($filterName);
+    }
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter($this->getFilterName(), [ $this, 'applyFilter']),
+        ];
+    }
+
+    public function applyFilter($value, array $options = []) {
+        $this->processOptions($options);
+        return new Markup($this->getHtml($value), 'UTF-8');
+    }
+
+    private function camel_to_snake($input)
+    {
+        if (0 === preg_match('/[A-Z]/', $input)) {
+            return $input;
+        }
+        $pattern = '/([a-z])([A-Z])/';
+        $r = strtolower(preg_replace_callback($pattern, function ($a) {
+            return $a[1].'_'.strtolower($a[2]);
+        }, $input));
+
+        return $r;
+    }
+
+    public function getTokenParsers()
+    {
+        return [];
+    }
+
+    public function getNodeVisitors()
+    {
+        return [];
+    }
+
+    public function getTests()
+    {
+        return [];
+    }
+
+    public function getFunctions()
+    {
+        return [];
+    }
+
+    public function getOperators()
+    {
+        return [];
+    }
+}

--- a/Formatter/TwigFilterTrait.php
+++ b/Formatter/TwigFilterTrait.php
@@ -18,13 +18,17 @@ trait TwigFilterTrait
     public function getFilters()
     {
         return [
-            new TwigFilter($this->getFilterName(), [ $this, 'applyFilter']),
+            new TwigFilter($this->getFilterName(), fn ($data, array $options = []) => $this->applyFormatter($data, $options))
         ];
     }
 
-    public function applyFilter($value, array $options = []) {
+    private function applyFormatter($data, array $options = []) {
+        if (!$this instanceof FormatterInterface) {
+            throw new \Exception('TwigFilterTrait can only used on FormatterInterface classes');
+        }
+
         $this->processOptions($options);
-        return new Markup($this->getHtml($value), 'UTF-8');
+        return new Markup($this->getHtml($data), 'UTF-8');
     }
 
     private function camel_to_snake($input)


### PR DESCRIPTION
Use Formatter as Twig_Filter

name of the filter is Formatter class name in snake_case

```twig
{{ someObject|blubber_formatter }}
```

```php
class BlubberFormatter extends AbstractFormatter implements TwigFilterFormatterInterface
{
    use TwigFilterTrait;

    public function getString($value)
    {
        return 'blubber ' . $this->options['option1'];
    }

    protected function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefault('option1', 321);
    }
}
```




Change name of the Filter:

```twig
{{ someObject|blubber }}
```

```php
class BlubberFormatter extends AbstractFormatter implements TwigFilterFormatterInterface
{
   ...
    protected function getFilterName(): ?string
    {
        return 'blubber';
    }

   ...
}
```

