### PR TITLE
fix(command): add ContainerAwareInterface

### DIFF
--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -31,6 +31,7 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -39,7 +40,7 @@ use whatwedo\CoreBundle\Command\Traits\ConsoleOutput;
 /**
  * Class BaseCommand.
  */
-abstract class BaseCommand extends Command
+abstract class BaseCommand extends Command implements ContainerAwareInterface
 {
     use ConsoleOutput;
     use ContainerAwareTrait;


### PR DESCRIPTION
This is needed, because otherwise the container is not injected.