### PR TITLE
fix(Formatter): do not call processOptions in the constructor

### DIFF
--- a/src/Formatter/AbstractFormatter.php
+++ b/src/Formatter/AbstractFormatter.php
@@ -15,7 +15,6 @@ abstract class AbstractFormatter implements FormatterInterface
 
     public function __construct()
     {
-        $this->processOptions();
     }
 
     public function getHtml(mixed $value): string


### PR DESCRIPTION
If processOptions() is called in the constructor, the required options are practically unusable since processOptions will try to resolve them based on an empty array